### PR TITLE
Add required files to the CPRS build directory

### DIFF
--- a/Packages/Order Entry Results Reporting/CPRS/CPRS-Chart/CMakeLists.txt
+++ b/Packages/Order Entry Results Reporting/CPRS/CPRS-Chart/CMakeLists.txt
@@ -16,6 +16,9 @@
 add_delphi_project(CPRSChart)
 #add_dependencies(CPRSChart ORDateLibXE3)
 
+
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/CPRSChart.TLB" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/CPRSChart.ridl" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 set(BUILD_DELPHI_XuDigSig_DIR "${CMAKE_CURRENT_SOURCE_DIR}/XuDigSig" CACHE PATH "Path to Folder that contains the MPL licensed files or local replacements")
 if(NOT BUILD_DELPHI_XuDigSig_DIR)
   message(WARNING "The CPRSv29 source on the FOIA site contained code that was


### PR DESCRIPTION
Add a set of copy commands to bring two files to the binary directory
where they need to reside before building CPRS